### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # anki-mcp
 
-A Model Context Protocol (MCP) server for interacting with Anki flashcards via the AnkiConnect add-on.
-This server exposes AnkiConnect actions as MCP tools, organized into logical services.
+A Model Context Protocol (MCP) server for interacting with Anki flashcards via the AnkiConnect add-on. This server exposes AnkiConnect actions as MCP tools, organized into logical services.
+
+<a href="https://glama.ai/mcp/servers/@ujisati/anki-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ujisati/anki-mcp/badge" alt="anki-mcp MCP server" />
+</a>
 
 ## Prerequisites
 
@@ -135,8 +138,6 @@ uv pip install -e .
 pytest
 ```
 
-
 ## Todo
 
 - [ ] Finish adding all AnkiConnect tools
-


### PR DESCRIPTION
This PR adds a badge for the [anki-mcp](https://glama.ai/mcp/servers/@ujisati/anki-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ujisati/anki-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ujisati/anki-mcp/badge" alt="anki-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.